### PR TITLE
Use master branch for circleci and codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Receipt scanner extracts information from your PDF or image receipts.
 
-[![CircleCI](https://img.shields.io/circleci/project/danschultzer/receipt-scanner.svg)](https://circleci.com/gh/danschultzer/receipt-scanner)
+[![CircleCI](https://img.shields.io/circleci/project/danschultzer/receipt-scanner/master.svg)](https://circleci.com/gh/danschultzer/receipt-scanner)
 [![NPM version](https://img.shields.io/npm/v/receipt-scanner.svg)](https://www.npmjs.com/package/receipt-scanner)
-[![Codecov](https://img.shields.io/codecov/c/github/danschultzer/receipt-scanner.svg)](https://codecov.io/gh/danschultzer/receipt-scanner)
+[![Codecov](https://img.shields.io/codecov/c/github/danschultzer/receipt-scanner/master.svg)](https://codecov.io/gh/danschultzer/receipt-scanner)
 
 ## Example
 


### PR DESCRIPTION
The current badges just use the most recent build, but on the readme we should actually just show the master branch results.