### PR TITLE
Bug fix opencv preprocessor

### DIFF
--- a/lib/image_processor/preprocessor/opencv-photo2scan.js
+++ b/lib/image_processor/preprocessor/opencv-photo2scan.js
@@ -156,11 +156,12 @@ function getTextElementsContours(im) {
     return ratio >= 5;
   });
 
-  return contoursList;
+  return { contours: contours, list: contoursList };
 }
 
 function rotate(paperMask, im, outfile, config) {
-  contoursList = getTextElementsContours(im);
+  contours = getTextElementsContours(im);
+  contoursList = contours.list;
 
   if(config.onlyFindTextInsidePaperContour) {
     // This is not necessary unless the paper haven't been deteced
@@ -168,7 +169,7 @@ function rotate(paperMask, im, outfile, config) {
       var contoursListCountPrevious = contoursList.length;
       // Remove all not inside the paper polygon
       contoursList = contoursList.filter(function(c) {
-        points = getContourPoints(contours, c[0]);
+        points = getContourPoints(contours.contours, c[0]);
         return polygonInPolygon(points, paperMask);
       });
       var removedContoursCount = contoursListCountPrevious - contoursList.length;


### PR DESCRIPTION
Contours was never returned from `getTextElementsContours()`

This resolves #15