### PR TITLE
Fix removeNoise

### DIFF
--- a/lib/image_processor/preprocessor/opencv-photo2scan.js
+++ b/lib/image_processor/preprocessor/opencv-photo2scan.js
@@ -350,15 +350,12 @@ function removeNoise(im, outfile, config) {
 
     im.medianBlur(blurKernel);
     im = im.adaptiveThreshold(255, ADAPTIVE_THRESH_GAUSSIAN_C = 1, THRESH_BINARY = 0, 21, 3);
-    structure = cv.imgproc.getStructuringElement(1, [6, 6]);
-    mask.erode(1, structure);
-    mask.dilate(11, structure);
 
     /* istanbul ignore if */
     if (config.verbose) {
       var filename = debugFilename(outfile);
       config.log("verbose[removeNoise]: Saved removed noise image as " + filename);
-      mask.save(filename);
+      im.save(filename);
     }
 
     return im;


### PR DESCRIPTION
Fix removeNoise to return im instead of mask.

This resvoles issue with removeNoise returned a black image instead of the correct one.

Removed unused code for mask.