### PR TITLE
Only include essential files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
   "bin": {
     "receipt-scanner": "./cli.js"
   },
+  "files":  [
+    "lib",
+    "cli.js",
+    "main.js"
+  ],
   "license": "MIT",
   "dependencies": {
     "chrono-node": "^1.2.4",


### PR DESCRIPTION
added `files` in `package.json` to only include essential files to the NPM release