### PR TITLE
Bug fix opencv-photo2scan

### DIFF
--- a/lib/image_processor/preprocessor/opencv-photo2scan.js
+++ b/lib/image_processor/preprocessor/opencv-photo2scan.js
@@ -210,7 +210,7 @@ function rotate(paperMask, im, outfile, config) {
   } else {
     median = (contoursList[middle][1].angle + contoursList[middle + 1][1].angle) / 2.0;
   }
-  noOfItems = contoursList.length * 0.15;
+  noOfItems = Math.floor(contoursList.length * 0.15);
   contoursList = contoursList.slice(noOfItems, contoursList.length - noOfItems);
   maxDif = 1.0;
   if (Math.abs(median - contoursList[contoursList.length - 1][1].angle) > maxDif || Math.abs(contoursList[0][1].angle - median) > maxDif) {


### PR DESCRIPTION
This fix a bug with `noOfItems` being `0.15` instead of `0`
this resolves `"error": "Cannot read property '1' of undefined"`