### PR TITLE
Load config before overriding preprocessor var

### DIFF
--- a/lib/image_processor/preprocessor.js
+++ b/lib/image_processor/preprocessor.js
@@ -21,8 +21,8 @@ Preprocessor.prototype._runPreprocessor = function(file_or_stream, outfile, call
     config = {};
 
   if (preprocessor instanceof Array) {
+    config = preprocessor[1]; // Before we override preprocessor
     preprocessor = preprocessor[0];
-    config = preprocessor[1];
   }
 
   config.log = self.processor.log;


### PR DESCRIPTION
Fixes bug introduced in #28. I'll try add a test case to prevent this.