### PR TITLE
Fix issue for when month and days get mix up 

### DIFF
--- a/lib/text_parser/date_parser.js
+++ b/lib/text_parser/date_parser.js
@@ -133,7 +133,6 @@ function chrono () {
           new parser.ENMonthNameLittleEndianParser(strictMode),
 
           // ES
-          new parser.ESSlashDateFormatParser(strictMode),
           new parser.ESMonthNameLittleEndianParser(strictMode)
         ],
 

--- a/test/lib/text_parser/date_parser_spec.js
+++ b/test/lib/text_parser/date_parser_spec.js
@@ -68,9 +68,14 @@ describe('DateParser', function () {
       })
     })
 
-    it('should handle (month name)/dd/yyyy', function () {
+    it('should handle EN (month name)/dd/yyyy', function () {
       var text = 'Mar 30 2016'
       assert.equal(extractValue(dateParser.allDates(text)), '2016-03-30')
+    })
+
+    it('should handle ES dd/(month name)/yyyy', function () {
+      var text = '15 Dic 2016'
+      assert.equal(extractValue(dateParser.allDates(text)), '2016-12-15')
     })
 
     it('should handle (d)d/(m)m/yyyy', function () {


### PR DESCRIPTION
Chrono favors ESSlashDateFormatParser.
We don’t need ESSlashDateFormatParser because ENSlashDateFormatParser alright takes care of mm/dd/yyyy and dd/mm/yyyy for us.