### PR TITLE
Set opencv as optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
     "commander": "^2.9.0",
     "mime": "^1.3.4",
     "node-tesseract": "^0.2.7",
-    "opencv": "^6.0.0",
     "pdf-text-extract": "^1.4.1",
     "progress": "^1.1.8",
     "tmp": "^0.0.31"
   },
   "optionalDependencies": {
     "gm": "^1.23.0",
+    "opencv": "^6.0.0",
     "sharp": "^0.16.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This package seems useful also without opencv, especially since imagemagick and graphicsmagick can be used as image preprocessors instead of opencv. Also, date/amount-parsing can be used on text strings regardless of image preprocessing. Thus, failing hard on the inability to find a local opencv seems harsh.